### PR TITLE
Bug 1205743, funnelcake53 config

### DIFF
--- a/desktop/funnelcake53/distribution/distribution.ini
+++ b/desktop/funnelcake53/distribution/distribution.ini
@@ -1,0 +1,13 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla53
+version=1.0
+about=Funnelcake October 2015
+
+[Preferences]
+app.partner.mozilla53="mozilla53"
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=53"

--- a/desktop/funnelcake53/repack.cfg
+++ b/desktop/funnelcake53/repack.cfg
@@ -1,0 +1,8 @@
+aus="funnelcake53"
+dist_id="funnelcake53"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+win64=false


### PR DESCRIPTION
A basic funnelcake config, with the usual tagged firstrun page to provide initial metrics. Adds win64=false to be explicit about that.