### PR TITLE
Bug 1208658 - Move old funnelcakes and add funnelcake 54 & 55.

### DIFF
--- a/desktop/funnelcake54/distribution/distribution.ini
+++ b/desktop/funnelcake54/distribution/distribution.ini
@@ -1,0 +1,13 @@
+# Partner Distribution Configuration File
+# Author: Francesco Polizzi (Firefox Growth) <fpolizzi@mozilla.com>
+
+[Global]
+id=mozilla54
+version=1.0
+about=Funnelcake October 2015
+
+[Preferences]
+app.partner.mozilla54="mozilla54"
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=54"

--- a/desktop/funnelcake54/repack.cfg
+++ b/desktop/funnelcake54/repack.cfg
@@ -1,0 +1,7 @@
+aus="funnelcake54"
+dist_id="funnelcake54"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true

--- a/desktop/funnelcake55/distribution/distribution.ini
+++ b/desktop/funnelcake55/distribution/distribution.ini
@@ -1,0 +1,14 @@
+# Partner Distribution Configuration File
+# Author: Francesco Polizzi (Firefox Growth) <fpolizzi@mozilla.com>
+
+[Global]
+id=mozilla55
+version=1.0
+about=Funnelcake October 2015
+
+[Preferences]
+app.partner.mozilla55="mozilla55"
+
+[LocalizablePreferences]
+browser.newtabpage.enhanced="FALSE"
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=55"

--- a/desktop/funnelcake55/distribution/distribution.ini
+++ b/desktop/funnelcake55/distribution/distribution.ini
@@ -10,5 +10,5 @@ about=Funnelcake October 2015
 app.partner.mozilla55="mozilla55"
 
 [LocalizablePreferences]
-browser.newtabpage.enhanced="false"
+browser.newtabpage.enhanced=false
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=55"

--- a/desktop/funnelcake55/distribution/distribution.ini
+++ b/desktop/funnelcake55/distribution/distribution.ini
@@ -10,5 +10,5 @@ about=Funnelcake October 2015
 app.partner.mozilla55="mozilla55"
 
 [LocalizablePreferences]
-browser.newtabpage.enhanced="FALSE"
+browser.newtabpage.enhanced="false"
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=55"

--- a/desktop/funnelcake55/repack.cfg
+++ b/desktop/funnelcake55/repack.cfg
@@ -1,0 +1,7 @@
+aus="funnelcake55"
+dist_id="funnelcake55"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true

--- a/old/funnelcake50/distribution/distribution.ini
+++ b/old/funnelcake50/distribution/distribution.ini
@@ -1,0 +1,13 @@
+# Partner Distribution Configuration File
+# Author: Francesco Polizzi (Firefox Growth) <fpolizzi@mozilla.com>
+
+[Global]
+id=mozilla50
+version=1.0
+about=Funnelcake October 2015
+
+[Preferences]
+app.partner.mozilla50="mozilla50"
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=50"

--- a/old/funnelcake50/repack.cfg
+++ b/old/funnelcake50/repack.cfg
@@ -1,0 +1,7 @@
+aus="funnelcake50"
+dist_id="funnelcake50"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true


### PR DESCRIPTION
Moved the old funnelcakes to /old/ and added funnelcake 54 and 55 configs via https://bugzilla.mozilla.org/show_bug.cgi?id=1208658. I wasn't 100% sure whether the FALSE flag needed quotations around it.

@mixedpuppy r?