### PR TITLE
Bug 1267305, First and 2nd run tests, r=cmore, jpetto

### DIFF
--- a/desktop/funnelcake75/distribution/distribution.ini
+++ b/desktop/funnelcake75/distribution/distribution.ini
@@ -1,0 +1,16 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla75
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla75="mozilla75"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=75&v=1"
+startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=75"
+

--- a/desktop/funnelcake75/distribution/distribution.ini
+++ b/desktop/funnelcake75/distribution/distribution.ini
@@ -13,4 +13,4 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=75&v=1"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=75"
-
+startup.homepage_welcome_url.additional=""

--- a/desktop/funnelcake75/repack.cfg
+++ b/desktop/funnelcake75/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake75"
+dist_id="funnelcake75"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true

--- a/desktop/funnelcake76/distribution/distribution.ini
+++ b/desktop/funnelcake76/distribution/distribution.ini
@@ -13,6 +13,7 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=76&v=2"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=76"
+startup.homepage_welcome_url.additional=""
 browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=76&v=2"
 browser.laterrun.pages.test.minTime="24"
 browser.laterrun.pages.test.minSessionCount="3"

--- a/desktop/funnelcake76/distribution/distribution.ini
+++ b/desktop/funnelcake76/distribution/distribution.ini
@@ -1,0 +1,20 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla76
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla76="mozilla76"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=76&v=2"
+startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=76"
+browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=76&v=2"
+browser.laterrun.pages.test.minTime="24"
+browser.laterrun.pages.test.minSessionCount="3"
+browser.laterrun.pages.test.requireBoth="true"
+

--- a/desktop/funnelcake76/repack.cfg
+++ b/desktop/funnelcake76/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake76"
+dist_id="funnelcake76"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true

--- a/desktop/funnelcake77/distribution/distribution.ini
+++ b/desktop/funnelcake77/distribution/distribution.ini
@@ -13,6 +13,7 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=77&v=3"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=77"
+startup.homepage_welcome_url.additional=""
 browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=77&v=3"
 browser.laterrun.pages.test.minTime="24"
 browser.laterrun.pages.test.minSessionCount="3"

--- a/desktop/funnelcake77/distribution/distribution.ini
+++ b/desktop/funnelcake77/distribution/distribution.ini
@@ -1,0 +1,20 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla77
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla77="mozilla77"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=77&v=3"
+startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=77"
+browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=77&v=3"
+browser.laterrun.pages.test.minTime="24"
+browser.laterrun.pages.test.minSessionCount="3"
+browser.laterrun.pages.test.requireBoth="true"
+

--- a/desktop/funnelcake77/repack.cfg
+++ b/desktop/funnelcake77/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake77"
+dist_id="funnelcake77"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true

--- a/desktop/funnelcake78/distribution/distribution.ini
+++ b/desktop/funnelcake78/distribution/distribution.ini
@@ -1,0 +1,20 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla78
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla78="mozilla78"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=78&v=4"
+startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=78"
+browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=78&v=4"
+browser.laterrun.pages.test.minTime="24"
+browser.laterrun.pages.test.minSessionCount="3"
+browser.laterrun.pages.test.requireBoth="true"
+

--- a/desktop/funnelcake78/distribution/distribution.ini
+++ b/desktop/funnelcake78/distribution/distribution.ini
@@ -13,6 +13,7 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=78&v=4"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=78"
+startup.homepage_welcome_url.additional=""
 browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=78&v=4"
 browser.laterrun.pages.test.minTime="24"
 browser.laterrun.pages.test.minSessionCount="3"

--- a/desktop/funnelcake78/repack.cfg
+++ b/desktop/funnelcake78/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake78"
+dist_id="funnelcake78"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true

--- a/desktop/funnelcake79/distribution/distribution.ini
+++ b/desktop/funnelcake79/distribution/distribution.ini
@@ -13,6 +13,7 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=79&v=5"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=79"
+startup.homepage_welcome_url.additional=""
 browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=79&v=5"
 browser.laterrun.pages.test.minTime="24"
 browser.laterrun.pages.test.minSessionCount="3"

--- a/desktop/funnelcake79/distribution/distribution.ini
+++ b/desktop/funnelcake79/distribution/distribution.ini
@@ -1,0 +1,20 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla79
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla79="mozilla79"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=79&v=5"
+startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=79"
+browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=79&v=5"
+browser.laterrun.pages.test.minTime="24"
+browser.laterrun.pages.test.minSessionCount="3"
+browser.laterrun.pages.test.requireBoth="true"
+

--- a/desktop/funnelcake79/repack.cfg
+++ b/desktop/funnelcake79/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake79"
+dist_id="funnelcake79"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true

--- a/desktop/funnelcake80/distribution/distribution.ini
+++ b/desktop/funnelcake80/distribution/distribution.ini
@@ -1,0 +1,20 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla80
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla80="mozilla80"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=80&v=6"
+startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=80"
+browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=80&v=6"
+browser.laterrun.pages.test.minTime="24"
+browser.laterrun.pages.test.minSessionCount="3"
+browser.laterrun.pages.test.requireBoth="true"
+

--- a/desktop/funnelcake80/distribution/distribution.ini
+++ b/desktop/funnelcake80/distribution/distribution.ini
@@ -13,6 +13,7 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=80&v=6"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=80"
+startup.homepage_welcome_url.additional=""
 browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=80&v=6"
 browser.laterrun.pages.test.minTime="24"
 browser.laterrun.pages.test.minSessionCount="3"

--- a/desktop/funnelcake80/repack.cfg
+++ b/desktop/funnelcake80/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake80"
+dist_id="funnelcake80"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true

--- a/desktop/funnelcake81/distribution/distribution.ini
+++ b/desktop/funnelcake81/distribution/distribution.ini
@@ -13,3 +13,4 @@ browser.usedOnWindows10=true
 [LocalizablePreferences]
 startup.homepage_welcome_url=""
 startup.homepage_override_url=""
+startup.homepage_welcome_url.additional=""

--- a/desktop/funnelcake81/distribution/distribution.ini
+++ b/desktop/funnelcake81/distribution/distribution.ini
@@ -1,0 +1,15 @@
+# Partner Distribution Configuration File
+# Author: Mozilla Release Engineering <release+funnelcake@mozilla.com>
+
+[Global]
+id=mozilla81
+version=1.0
+about=Funnelcake Q2 2016 - First and Second Run pages
+
+[Preferences]
+app.partner.mozilla81="mozilla81"
+browser.usedOnWindows10=true
+
+[LocalizablePreferences]
+startup.homepage_welcome_url=""
+startup.homepage_override_url=""

--- a/desktop/funnelcake81/repack.cfg
+++ b/desktop/funnelcake81/repack.cfg
@@ -1,0 +1,12 @@
+aus="funnelcake81"
+dist_id="funnelcake81"
+dist_version="1.0"
+linux-i686=false
+locales="en-US"
+mac=false
+win32=true
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true


### PR DESCRIPTION
@chrismore for your review.

Assumptions:
- the &v=N query arg should match the vN listed in the bug
- that &v=1 was wanted in first case
- setting a string pref to "" actually wipes an in-app preference

I've set 
- browser.usedOnWindows10 to true, and
- startup.homepage_welcome_url.additional to ""

to avoid additionalPage being set at [this code](https://dxr.mozilla.org/mozilla-release/source/browser/components/nsBrowserContentHandler.js#571).