### PR TITLE
Bug 1267305 fixups

### DIFF
--- a/desktop/funnelcake75/distribution/distribution.ini
+++ b/desktop/funnelcake75/distribution/distribution.ini
@@ -9,8 +9,6 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla75="mozilla75"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=75&v=1"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=75"
-startup.homepage_welcome_url.additional=""
+startup.homepage_welcome_url.additional="about:blank"

--- a/desktop/funnelcake76/distribution/distribution.ini
+++ b/desktop/funnelcake76/distribution/distribution.ini
@@ -9,13 +9,11 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla76="mozilla76"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=76&v=2"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=76"
-startup.homepage_welcome_url.additional=""
-browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=76&v=2"
-browser.laterrun.pages.test.minTime="24"
-browser.laterrun.pages.test.minSessionCount="3"
-browser.laterrun.pages.test.requireBoth="true"
+startup.homepage_welcome_url.additional="about:blank"
+browser.laterrun.pages.test.url="https://www.mozilla.org/en-US/firefox/46.0.1/secondrun/?f=76&v=2"
+browser.laterrun.pages.test.minimumHoursSinceInstall=24
+browser.laterrun.pages.test.minimumSessionCount=3
+browser.laterrun.pages.test.requireBoth=true
 

--- a/desktop/funnelcake77/distribution/distribution.ini
+++ b/desktop/funnelcake77/distribution/distribution.ini
@@ -9,13 +9,11 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla77="mozilla77"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=77&v=3"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=77"
-startup.homepage_welcome_url.additional=""
-browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=77&v=3"
-browser.laterrun.pages.test.minTime="24"
-browser.laterrun.pages.test.minSessionCount="3"
-browser.laterrun.pages.test.requireBoth="true"
+startup.homepage_welcome_url.additional="about:blank"
+browser.laterrun.pages.test.url="https://www.mozilla.org/en-US/firefox/46.0.1/secondrun/?f=77&v=3"
+browser.laterrun.pages.test.minimumHoursSinceInstall=24
+browser.laterrun.pages.test.minimumSessionCount=3
+browser.laterrun.pages.test.requireBoth=true
 

--- a/desktop/funnelcake78/distribution/distribution.ini
+++ b/desktop/funnelcake78/distribution/distribution.ini
@@ -9,13 +9,11 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla78="mozilla78"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=78&v=4"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=78"
-startup.homepage_welcome_url.additional=""
-browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=78&v=4"
-browser.laterrun.pages.test.minTime="24"
-browser.laterrun.pages.test.minSessionCount="3"
-browser.laterrun.pages.test.requireBoth="true"
+startup.homepage_welcome_url.additional="about:blank"
+browser.laterrun.pages.test.url="https://www.mozilla.org/en-US/firefox/46.0.1/secondrun/?f=78&v=4"
+browser.laterrun.pages.test.minimumHoursSinceInstall=24
+browser.laterrun.pages.test.minimumSessionCount=3
+browser.laterrun.pages.test.requireBoth=true
 

--- a/desktop/funnelcake79/distribution/distribution.ini
+++ b/desktop/funnelcake79/distribution/distribution.ini
@@ -9,13 +9,11 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla79="mozilla79"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=79&v=5"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=79"
-startup.homepage_welcome_url.additional=""
-browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=79&v=5"
-browser.laterrun.pages.test.minTime="24"
-browser.laterrun.pages.test.minSessionCount="3"
-browser.laterrun.pages.test.requireBoth="true"
+startup.homepage_welcome_url.additional="about:blank"
+browser.laterrun.pages.test.url="https://www.mozilla.org/en-US/firefox/46.0.1/secondrun/?f=79&v=5"
+browser.laterrun.pages.test.minimumHoursSinceInstall=24
+browser.laterrun.pages.test.minimumSessionCount=3
+browser.laterrun.pages.test.requireBoth=true
 

--- a/desktop/funnelcake80/distribution/distribution.ini
+++ b/desktop/funnelcake80/distribution/distribution.ini
@@ -9,13 +9,11 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla80="mozilla80"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=80&v=6"
 startup.homepage_override_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/whatsnew/?oldversion=%OLD_VERSION%&f=80"
-startup.homepage_welcome_url.additional=""
-browser.laterrun.pages.test.url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/secondrun/?f=80&v=6"
-browser.laterrun.pages.test.minTime="24"
-browser.laterrun.pages.test.minSessionCount="3"
-browser.laterrun.pages.test.requireBoth="true"
+startup.homepage_welcome_url.additional="about:blank"
+browser.laterrun.pages.test.url="https://www.mozilla.org/en-US/firefox/46.0.1/secondrun/?f=80&v=6"
+browser.laterrun.pages.test.minimumHoursSinceInstall=24
+browser.laterrun.pages.test.minimumSessionCount=3
+browser.laterrun.pages.test.requireBoth=true
 

--- a/desktop/funnelcake81/distribution/distribution.ini
+++ b/desktop/funnelcake81/distribution/distribution.ini
@@ -9,8 +9,6 @@ about=Funnelcake Q2 2016 - First and Second Run pages
 [Preferences]
 app.partner.mozilla81="mozilla81"
 browser.usedOnWindows10=true
-
-[LocalizablePreferences]
-startup.homepage_welcome_url=""
-startup.homepage_override_url=""
-startup.homepage_welcome_url.additional=""
+startup.homepage_welcome_url="about:blank"
+startup.homepage_override_url="about:blank"
+startup.homepage_welcome_url.additional="about:blank"


### PR DESCRIPTION
Fixes several issues with #16 
- url prefs should be set to "about:blank" instead of "" to ensure no tab loads
- LaterRun pref minTime should be minimumHoursSinceInstall; minSessionCount should be minimumSessionCount
- LocalizablePreferences yields prefs set to (eg) `data:text/plain,browser.laterrun.pages.test.url=https://www.mozilla.org/en-US/%APP%/%VERSION%/secondrun/?f=76&v=2`. This causes LaterRun to [reject the url](https://dxr.mozilla.org/mozilla-release/source/browser/modules/LaterRun.jsm#140). Swapping to Preferences avoids this, and lets us type the boolean and int prefs correctly
- LaterRun doesn't interpolate any variables like %VERSION% ([bug 1270707](https://bugzilla.mozilla.org/show_bug.cgi?id=1270707)) so we have to hardcode values in `browser.laterrun.pages.test.url`. Good thing we've only got one locale here