### PR TITLE
Bug 1323022 - funnelcake95/96/97

### DIFF
--- a/desktop/funnelcake95/distribution/distribution.ini
+++ b/desktop/funnelcake95/distribution/distribution.ini
@@ -1,0 +1,11 @@
+# Partner Distribution Configuration File
+# Author: Chris More <cmore@mozilla.com>
+
+[Global]
+id=mozilla95
+version=1.0
+about=Funnelcake Campaign Retention Q4 2016 - variation 1
+
+[Preferences]
+app.partner.mozilla95="mozilla95"
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=95"

--- a/desktop/funnelcake95/repack.cfg
+++ b/desktop/funnelcake95/repack.cfg
@@ -1,0 +1,14 @@
+aus="funnelcake95"
+dist_id="funnelcake95"
+dist_version="1.0"
+locales="en-US"
+linux-i686=false
+mac=false
+win32=true
+win64=false
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true
+output_dir="partner-repacks/funnelcake95/%(platform)s/%(locale)s"

--- a/desktop/funnelcake96/distribution/distribution.ini
+++ b/desktop/funnelcake96/distribution/distribution.ini
@@ -1,0 +1,11 @@
+# Partner Distribution Configuration File
+# Author: Chris More <cmore@mozilla.com>
+
+[Global]
+id=mozilla96
+version=1.0
+about=Funnelcake Campaign Retention Q4 2016 - variation 2
+
+[Preferences]
+app.partner.mozilla96="mozilla96"
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=96"

--- a/desktop/funnelcake96/repack.cfg
+++ b/desktop/funnelcake96/repack.cfg
@@ -1,0 +1,14 @@
+aus="funnelcake96"
+dist_id="funnelcake96"
+dist_version="1.0"
+locales="en-US"
+linux-i686=false
+mac=false
+win32=true
+win64=false
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true
+output_dir="partner-repacks/funnelcake96/%(platform)s/%(locale)s"

--- a/desktop/funnelcake97/distribution/distribution.ini
+++ b/desktop/funnelcake97/distribution/distribution.ini
@@ -1,0 +1,11 @@
+# Partner Distribution Configuration File
+# Author: Chris More <cmore@mozilla.com>
+
+[Global]
+id=mozilla97
+version=1.0
+about=Funnelcake Campaign Retention Q4 2016 - control
+
+[Preferences]
+app.partner.mozilla97="mozilla97"
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=97"

--- a/desktop/funnelcake97/repack.cfg
+++ b/desktop/funnelcake97/repack.cfg
@@ -1,0 +1,14 @@
+aus="funnelcake97"
+dist_id="funnelcake97"
+dist_version="1.0"
+locales="en-US"
+linux-i686=false
+mac=false
+win32=true
+win64=false
+
+# Upload params
+s3cfg=~/.s3cfg-mozilla
+bucket="net-mozaws-prod-delivery-firefox"
+upload_to_candidates=true
+output_dir="partner-repacks/funnelcake97/%(platform)s/%(locale)s"


### PR DESCRIPTION
Drops
* whatsnew page to match vanilla builds
* windows 10 pref, deprecated by bug 1274633
* blocking the extra first page (startup.homepage_welcome_url.additional), which bug 1274633 removed too