### PR TITLE
onboard.environment="production".  needs to land before final build

### DIFF
--- a/desktop/funnelcake110/repack.cfg
+++ b/desktop/funnelcake110/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v3/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v4/%(platform)s/%(locale)s"

--- a/desktop/funnelcake111/distribution/distribution.ini
+++ b/desktop/funnelcake111/distribution/distribution.ini
@@ -12,3 +12,4 @@ startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/f
 browser.migrate.automigrate.enabled=true
 distribution.variation="contentVariationA"
 browser.newtab.preload=false
+onboard.environment="production"

--- a/desktop/funnelcake111/repack.cfg
+++ b/desktop/funnelcake111/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v3/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v4/%(platform)s/%(locale)s"

--- a/desktop/funnelcake112/distribution/distribution.ini
+++ b/desktop/funnelcake112/distribution/distribution.ini
@@ -12,3 +12,4 @@ startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/f
 browser.migrate.automigrate.enabled=true
 distribution.variation="contentVariationB"
 browser.newtab.preload=false
+onboard.environment="production"

--- a/desktop/funnelcake112/repack.cfg
+++ b/desktop/funnelcake112/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v3/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v4/%(platform)s/%(locale)s"

--- a/desktop/funnelcake113/distribution/distribution.ini
+++ b/desktop/funnelcake113/distribution/distribution.ini
@@ -11,3 +11,4 @@ app.partner.mozilla107="mozilla113"
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=113"
 distribution.variation="contentVariationA"
 browser.newtab.preload=false
+onboard.environment="production"

--- a/desktop/funnelcake113/repack.cfg
+++ b/desktop/funnelcake113/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v3/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v4/%(platform)s/%(locale)s"


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1348127#c118 .
We don't want to test with these; we want to have this set before the final production build.