### PR TITLE
v10

### DIFF
--- a/desktop/funnelcake110/distribution/distribution.ini
+++ b/desktop/funnelcake110/distribution/distribution.ini
@@ -7,5 +7,5 @@ version=1.0
 about=Funnelcake Onboarding Q2 2017
 
 [Preferences]
-app.partner.mozilla107="mozilla110"
+app.partner.mozilla110="mozilla110"
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=110"

--- a/desktop/funnelcake110/repack.cfg
+++ b/desktop/funnelcake110/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v7/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v10/%(platform)s/%(locale)s"

--- a/desktop/funnelcake111/distribution/distribution.ini
+++ b/desktop/funnelcake111/distribution/distribution.ini
@@ -7,9 +7,16 @@ version=1.0
 about=Funnelcake Onboarding Q2 2017
 
 [Preferences]
-app.partner.mozilla107="mozilla111"
+app.partner.mozilla111="mozilla111"
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=111"
 browser.migrate.automigrate.enabled=true
 distribution.variation="contentVariationA"
 browser.newtab.preload=false
-onboard.environment="production"
+browser.startup.firstrunSkipsHomepage=true
+browser.shell.skipDefaultBrowserCheckOnFirstRun=true
+browser.newtabpage.directory.source="chrome://browser/content/newtab/alternativeDefaultSites.json"
+browser.newtabpage.compact=true
+browser.newtabpage.rows=2
+browser.newtabpage.columns=6
+browser.newtabpage.thumbnailPlaceholder=true
+datareporting.policy.firstRunURL="https://www.mozilla.org/privacy/firefox/"

--- a/desktop/funnelcake111/distribution/distribution.ini
+++ b/desktop/funnelcake111/distribution/distribution.ini
@@ -20,3 +20,6 @@ browser.newtabpage.rows=2
 browser.newtabpage.columns=6
 browser.newtabpage.thumbnailPlaceholder=true
 datareporting.policy.firstRunURL="https://www.mozilla.org/privacy/firefox/"
+
+[LocalizablePreferences]
+browser.startup.homepage="about:newtab"

--- a/desktop/funnelcake111/repack.cfg
+++ b/desktop/funnelcake111/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v7/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v10/%(platform)s/%(locale)s"

--- a/desktop/funnelcake112/distribution/distribution.ini
+++ b/desktop/funnelcake112/distribution/distribution.ini
@@ -7,9 +7,16 @@ version=1.0
 about=Funnelcake Onboarding Q2 2017
 
 [Preferences]
-app.partner.mozilla107="mozilla112"
+app.partner.mozilla112="mozilla112"
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=112"
 browser.migrate.automigrate.enabled=true
 distribution.variation="contentVariationB"
 browser.newtab.preload=false
-onboard.environment="production"
+browser.startup.firstrunSkipsHomepage=true
+browser.shell.skipDefaultBrowserCheckOnFirstRun=true
+browser.newtabpage.directory.source="chrome://browser/content/newtab/alternativeDefaultSites.json"
+browser.newtabpage.compact=true
+browser.newtabpage.rows=2
+browser.newtabpage.columns=6
+browser.newtabpage.thumbnailPlaceholder=true
+datareporting.policy.firstRunURL="https://www.mozilla.org/privacy/firefox/"

--- a/desktop/funnelcake112/distribution/distribution.ini
+++ b/desktop/funnelcake112/distribution/distribution.ini
@@ -20,3 +20,6 @@ browser.newtabpage.rows=2
 browser.newtabpage.columns=6
 browser.newtabpage.thumbnailPlaceholder=true
 datareporting.policy.firstRunURL="https://www.mozilla.org/privacy/firefox/"
+
+[LocalizablePreferences]
+browser.startup.homepage="about:newtab"

--- a/desktop/funnelcake112/repack.cfg
+++ b/desktop/funnelcake112/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v7/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v10/%(platform)s/%(locale)s"

--- a/desktop/funnelcake113/distribution/distribution.ini
+++ b/desktop/funnelcake113/distribution/distribution.ini
@@ -7,8 +7,15 @@ version=1.0
 about=Funnelcake Onboarding Q2 2017
 
 [Preferences]
-app.partner.mozilla107="mozilla113"
+app.partner.mozilla113="mozilla113"
 startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=113"
 distribution.variation="contentVariationA"
 browser.newtab.preload=false
-onboard.environment="production"
+browser.startup.firstrunSkipsHomepage=true
+browser.shell.skipDefaultBrowserCheckOnFirstRun=true
+browser.newtabpage.directory.source="chrome://browser/content/newtab/alternativeDefaultSites.json"
+browser.newtabpage.compact=true
+browser.newtabpage.rows=2
+browser.newtabpage.columns=6
+browser.newtabpage.thumbnailPlaceholder=true
+datareporting.policy.firstRunURL="https://www.mozilla.org/privacy/firefox/"

--- a/desktop/funnelcake113/distribution/distribution.ini
+++ b/desktop/funnelcake113/distribution/distribution.ini
@@ -19,3 +19,6 @@ browser.newtabpage.rows=2
 browser.newtabpage.columns=6
 browser.newtabpage.thumbnailPlaceholder=true
 datareporting.policy.firstRunURL="https://www.mozilla.org/privacy/firefox/"
+
+[LocalizablePreferences]
+browser.startup.homepage="about:newtab"

--- a/desktop/funnelcake113/repack.cfg
+++ b/desktop/funnelcake113/repack.cfg
@@ -13,4 +13,4 @@ bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,
 # to avoid caching issues on archive.m.o
-output_dir="partner-repacks/%(partner_distro)s/v7/%(platform)s/%(locale)s"
+output_dir="partner-repacks/%(partner_distro)s/v10/%(platform)s/%(locale)s"


### PR DESCRIPTION
- bumps to v10
- fixes `app.partner` numbering
- removes `onboard.environment` until we're ready for the final build
- adds the prefs in https://bugzilla.mozilla.org/show_bug.cgi?id=1360400#c2 , other than `onboard.environment`.  Also, ignoring `browser.startup.homepage` because of https://bugzilla.mozilla.org/show_bug.cgi?id=1348127#c100