### PR TITLE
Fix uploads for 59.0.3 funnelcake builds

### DIFF
--- a/desktop/funnelcake133/repack.cfg
+++ b/desktop/funnelcake133/repack.cfg
@@ -8,7 +8,7 @@ win32=true
 win64=true
 
 # Upload params
-s3cfg=~/.s3cfg-mozilla
+s3cfg=/builds/release-s3cfg
 bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,

--- a/desktop/funnelcake134/repack.cfg
+++ b/desktop/funnelcake134/repack.cfg
@@ -8,7 +8,7 @@ win32=true
 win64=true
 
 # Upload params
-s3cfg=~/.s3cfg-mozilla
+s3cfg=/builds/release-s3cfg
 bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,

--- a/desktop/funnelcake135/repack.cfg
+++ b/desktop/funnelcake135/repack.cfg
@@ -8,7 +8,7 @@ win32=true
 win64=true
 
 # Upload params
-s3cfg=~/.s3cfg-mozilla
+s3cfg=/builds/release-s3cfg
 bucket="net-mozaws-prod-delivery-firefox"
 upload_to_candidates=true
 # NB: increment the .../vN/... for each configuration iteration,


### PR DESCRIPTION
Noticed the builds were missing in the 59.0.3 build1 candidates dir, and tracked it down to this in a repack log:

19:18:30     INFO -  2018-04-27 19:18:30,893 - WARNING - s3cfg is set in the repack config, but the file it points to (~/.s3cfg-mozilla) doesn't exist.

~/.s3cfg-mozilla works fine for partner-repack1 but not on the mac buildbot hardware. This patch just fixes us up if we do any more 59 builds. The new system for 60.0 doesn't care about this parameter.