### PR TITLE
Bug 1493597 - Funnelcake 138 & 139

### DIFF
--- a/desktop/funnelcake138/distribution/distribution.ini
+++ b/desktop/funnelcake138/distribution/distribution.ini
@@ -7,4 +7,3 @@ about=Funnelcake Taskbar Pinning Control
 
 [Preferences]
 app.partner.mozilla138="mozilla138"
-startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=138"

--- a/desktop/funnelcake138/distribution/distribution.ini
+++ b/desktop/funnelcake138/distribution/distribution.ini
@@ -1,0 +1,10 @@
+# Partner Distribution Configuration File
+
+[Global]
+id=mozilla138
+version=1.0
+about=Funnelcake Taskbar Pinning Control
+
+[Preferences]
+app.partner.mozilla138="mozilla138"
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=138"

--- a/desktop/funnelcake138/repack.cfg
+++ b/desktop/funnelcake138/repack.cfg
@@ -1,0 +1,10 @@
+# funnelcake138
+locales="en-US"
+linux-i686=false
+linux-x86_64=false
+mac=false
+win32=false
+win64=true
+
+# Upload params
+upload_to_candidates=true

--- a/desktop/funnelcake139/distribution/distribution.ini
+++ b/desktop/funnelcake139/distribution/distribution.ini
@@ -7,4 +7,3 @@ about=Funnelcake Taskbar Pinning Test
 
 [Preferences]
 app.partner.mozilla139="mozilla139"
-startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=139"

--- a/desktop/funnelcake139/distribution/distribution.ini
+++ b/desktop/funnelcake139/distribution/distribution.ini
@@ -1,0 +1,10 @@
+# Partner Distribution Configuration File
+
+[Global]
+id=mozilla139
+version=1.0
+about=Funnelcake Taskbar Pinning Test
+
+[Preferences]
+app.partner.mozilla139="mozilla139"
+startup.homepage_welcome_url="https://www.mozilla.org/%LOCALE%/%APP%/%VERSION%/firstrun/?f=139"

--- a/desktop/funnelcake139/distribution/setup.ini
+++ b/desktop/funnelcake139/distribution/setup.ini
@@ -1,0 +1,2 @@
+[Testing]
+Win10TaskbarPin=1

--- a/desktop/funnelcake139/repack.cfg
+++ b/desktop/funnelcake139/repack.cfg
@@ -6,8 +6,11 @@ mac=false
 win32=false
 win64=true
 
-# custom installer
-replacement_setup_exe="TBD"
+# custom installer from
+#  https://bugzilla.mozilla.org/attachment.cgi?id=9023806&action=edit
+# compiled and signed at
+#  https://treeherder.mozilla.org/#/jobs?repo=mozilla-release&revision=b054ab8cb4da2d2970135b0b8066a0c0a51ed79f
+replacement_setup_exe="https://queue.taskcluster.net/v1/task/BiLFx2vFTCW4vo89-PAivw/runs/0/artifacts/public/build/setup.exe"
 
 # Upload params
 upload_to_candidates=true

--- a/desktop/funnelcake139/repack.cfg
+++ b/desktop/funnelcake139/repack.cfg
@@ -1,0 +1,13 @@
+# funnelcake139
+locales="en-US"
+linux-i686=false
+linux-x86_64=false
+mac=false
+win32=false
+win64=true
+
+# custom installer
+replacement_setup_exe="TBD"
+
+# Upload params
+upload_to_candidates=true

--- a/desktop/funnelcake139/repack.cfg
+++ b/desktop/funnelcake139/repack.cfg
@@ -10,7 +10,7 @@ win64=true
 #  https://bugzilla.mozilla.org/attachment.cgi?id=9023806&action=edit
 # compiled and signed at
 #  https://treeherder.mozilla.org/#/jobs?repo=mozilla-release&revision=b054ab8cb4da2d2970135b0b8066a0c0a51ed79f
-replacement_setup_exe="https://queue.taskcluster.net/v1/task/BiLFx2vFTCW4vo89-PAivw/runs/0/artifacts/public/build/setup.exe"
+replacement_setup_exe="https://queue.taskcluster.net/v1/task/BiLFx2vFTCW4vo89-PAivw/runs/1/artifacts/public/build/setup.exe"
 
 # Upload params
 upload_to_candidates=true


### PR DESCRIPTION
Mike, these configs should do the trick for 138 (control) and 139 (test). Romain and I discussed (on the gdoc) having a full installer for the control so we're comparing applies with apples retention-wise. I'll need to add the url to the custom stub once the patch has reviewed and I've built it on mozilla-release.

In other news, the parameters which no longer do anything have been cleaned out - `aus, dist_id, dist_version, s3cfg, bucket,` and `output_dir`. RE the last, we no longer need to bump the config for a respin. Would a mozilla-partners/config_template repo, storing the latest minimal config, be useful for quickly creating new configs ?